### PR TITLE
Potential fix for code scanning alert no. 3: Disabled Spring CSRF protection

### DIFF
--- a/user-service/src/main/java/com/management/userservice/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/management/userservice/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable()
+        http
             .authorizeRequests()
             .antMatchers("/api/auth/**").permitAll()
             .antMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Allow OPTIONS requests for CORS preflight


### PR DESCRIPTION
Potential fix for [https://github.com/erdemerbaba/general-purpose-inclusive-devops-ecosystem/security/code-scanning/3](https://github.com/erdemerbaba/general-purpose-inclusive-devops-ecosystem/security/code-scanning/3)

To fix this CSRF vulnerability, remove the explicit disabling of CSRF protection (`http.csrf().disable()`) from the `configure(HttpSecurity http)` method. If certain endpoints need to be accessible without CSRF tokens (such as `/api/auth/**` for login or registration), these should be handled through appropriate configuration (for example, using `.csrf().ignoringAntMatchers("/api/auth/**")` in newer Spring versions or `.csrf().requireCsrfProtectionMatcher(...)` in older versions). The rest of the endpoints should retain CSRF protection since browser-based clients (or web UIs) may interact with them. In the provided snippet, simply removing `.disable()` allows the default protection to remain in place.

Edit file: `user-service/src/main/java/com/management/userservice/config/SecurityConfig.java`, specifically lines 36-44 where CSRF is disabled. Remove `.disable()`, chaining `.csrf()` instead, or completely omit explicit CSRF configuration to let Spring Security apply the secure default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
